### PR TITLE
[REFACT] Bring credentials outside

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -308,3 +308,4 @@ pyrightconfig.json
 ### Vercel ###
 
 # End of https://www.toptal.com/developers/gitignore/api/django,nextjs,python,remix+vercel,vercel
+backend/backend/.credentials

--- a/backend/backend/.credentials
+++ b/backend/backend/.credentials
@@ -1,0 +1,1 @@
+crimson|@123qaz123

--- a/backend/backend/.credentials
+++ b/backend/backend/.credentials
@@ -1,1 +1,0 @@
-crimson|@123qaz123

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -86,12 +86,19 @@ WSGI_APPLICATION = "backend.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
+import os
+
+# Read credentials from .credentials file
+with open(os.path.join(Path(__file__).resolve().parent, ".credentials"), "r") as f:
+    credentials = f.readline().split("|")
+
+# Extract user and password
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'foundermatchingdb',
-        'USER': 'crimson',
-        'PASSWORD': '@123qaz123',
+        'USER': credentials[0].strip(),
+        'PASSWORD': credentials[1].strip(),
         'HOST': 'localhost',
         'PORT': '5432',
     }


### PR DESCRIPTION
As title. The credential file is located in `./backend/backend/,credentials`. It is a text file, The format of the file is `username|p@ssword`.
![image](https://github.com/user-attachments/assets/30b882be-b975-46f1-9df3-d0bec68b07c9)
The file should be untracked.
If the file does not exist in your repo after merging, create one yourself according to the instruction above.